### PR TITLE
Match Jsoniter lowercase errors

### DIFF
--- a/shared/src/main/scala/cats/interop/jsoniter/package.scala
+++ b/shared/src/main/scala/cats/interop/jsoniter/package.scala
@@ -44,7 +44,7 @@ private inline def jsonValueCodec[A, B[_], C[_]](name: String, from: B[A] => Opt
     val decoded = codec.decodeValue(in, if default == nullValue then codec.nullValue else to(default))
     from(decoded) match {
       case Some(value) => value
-      case None        => in.decodeError(s"Cannot create $name without elements")
+      case None        => in.decodeError(s"cannot create $name without elements")
     }
   }
 

--- a/shared/src/test/scala/cats/interop/jsoniter/NonEmptyListCodecSuite.scala
+++ b/shared/src/test/scala/cats/interop/jsoniter/NonEmptyListCodecSuite.scala
@@ -28,12 +28,12 @@ class NonEmptyListCodecSuite extends AnyFunSuite with Matchers {
 
   test("decoding should fail for JSON null") {
     val thrown = the[JsonReaderException] thrownBy readFromString[Nel]("""{"value":null}""")
-    thrown.getMessage should startWith("Cannot create NonEmptyList without elements")
+    thrown.getMessage should startWith("cannot create NonEmptyList without elements")
   }
 
   test("decoding should fail for JSON empty array") {
     val thrown = the[JsonReaderException] thrownBy readFromString[Nel]("""{"value":[]}""")
-    thrown.getMessage should startWith("Cannot create NonEmptyList without elements")
+    thrown.getMessage should startWith("cannot create NonEmptyList without elements")
   }
 
   test("decoding should succeed for JSON array with elements") {

--- a/shared/src/test/scala/cats/interop/jsoniter/NonEmptySetCodecSuite.scala
+++ b/shared/src/test/scala/cats/interop/jsoniter/NonEmptySetCodecSuite.scala
@@ -28,12 +28,12 @@ class NonEmptySetCodecSuite extends AnyFunSuite with Matchers {
 
   test("decoding should fail for JSON null") {
     val thrown = the[JsonReaderException] thrownBy readFromString[Nes]("""{"value":null}""")
-    thrown.getMessage should startWith("Cannot create NonEmptySet without elements")
+    thrown.getMessage should startWith("cannot create NonEmptySet without elements")
   }
 
   test("decoding should fail for JSON empty array") {
     val thrown = the[JsonReaderException] thrownBy readFromString[Nes]("""{"value":[]}""")
-    thrown.getMessage should startWith("Cannot create NonEmptySet without elements")
+    thrown.getMessage should startWith("cannot create NonEmptySet without elements")
   }
 
   test("decoding should succeed for JSON array with elements") {

--- a/shared/src/test/scala/cats/interop/jsoniter/NonEmptyVectorCodecSuite.scala
+++ b/shared/src/test/scala/cats/interop/jsoniter/NonEmptyVectorCodecSuite.scala
@@ -28,12 +28,12 @@ class NonEmptyVectorCodecSuite extends AnyFunSuite with Matchers {
 
   test("decoding should fail for JSON null") {
     val thrown = the[JsonReaderException] thrownBy readFromString[Nev]("""{"value":null}""")
-    thrown.getMessage should startWith("Cannot create NonEmptyVector without elements")
+    thrown.getMessage should startWith("cannot create NonEmptyVector without elements")
   }
 
   test("decoding should fail for JSON empty array") {
     val thrown = the[JsonReaderException] thrownBy readFromString[Nev]("""{"value":[]}""")
-    thrown.getMessage should startWith("Cannot create NonEmptyVector without elements")
+    thrown.getMessage should startWith("cannot create NonEmptyVector without elements")
   }
 
   test("decoding should succeed for JSON array with elements") {


### PR DESCRIPTION
Errors coming from Jsoniter start with lowercase, so we try to adhere to this standard.